### PR TITLE
Update to go-re2 prerelease

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/magefile/mage v1.15.0
 	github.com/wasilibs/go-aho-corasick v0.5.0
 	github.com/wasilibs/go-libinjection v0.4.0
-	github.com/wasilibs/go-re2 v1.4.0
+	github.com/wasilibs/go-re2 v1.5.0-pre.1
 )
 
 require (
@@ -17,6 +17,7 @@ require (
 	github.com/tidwall/gjson v1.17.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/wasilibs/wazerox v0.0.0-20231218050519-52f5e22ee8b5 // indirect
 	golang.org/x/net v0.11.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	rsc.io/binaryregexp v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/wasilibs/go-aho-corasick v0.5.0
 	github.com/wasilibs/go-libinjection v0.4.0
 	github.com/wasilibs/go-re2 v1.5.0-pre.1
+	golang.org/x/sync v0.3.0
 )
 
 require (
@@ -19,6 +20,5 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/wasilibs/wazerox v0.0.0-20231218050519-52f5e22ee8b5 // indirect
 	golang.org/x/net v0.11.0 // indirect
-	golang.org/x/sync v0.3.0 // indirect
 	rsc.io/binaryregexp v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,7 +23,11 @@ github.com/wasilibs/go-libinjection v0.4.0 h1:dr1Y/kM/gmoA7eSfdf+CvCcmzwsz2jVYjN
 github.com/wasilibs/go-libinjection v0.4.0/go.mod h1:zD7fNXKSaTKoSTmrfuP9Gc16alNEgwkZaHIeDDk3WWM=
 github.com/wasilibs/go-re2 v1.4.0 h1:Jp6BM8G/zajgY1BCQUm3i7oGMdR1gA5EBv87wGd2ysc=
 github.com/wasilibs/go-re2 v1.4.0/go.mod h1:hLzlKjEgON+17hWjikLx8hJBkikyjQH/lsqCy9t6tIY=
+github.com/wasilibs/go-re2 v1.5.0-pre.1 h1:lJ0RGE6xp9hzFouzLrbEbzdZhpaqzg4rU2rA57eJLmI=
+github.com/wasilibs/go-re2 v1.5.0-pre.1/go.mod h1:GAociXj3tyaHNF0zuZdhEHuODXbPsFpOdg8vuAAq2pw=
 github.com/wasilibs/nottinygc v0.4.0 h1:h1TJMihMC4neN6Zq+WKpLxgd9xCFMw7O9ETLwY2exJQ=
+github.com/wasilibs/wazerox v0.0.0-20231218050519-52f5e22ee8b5 h1:7GQgc4ewesYeFF8bNxKvsT4q6ngGnGBkCFmwHs1ldwI=
+github.com/wasilibs/wazerox v0.0.0-20231218050519-52f5e22ee8b5/go.mod h1:IQNVyA4d1hWIe23mlMMuqXjyWMdndgSlNx6FqBkwPsM=
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/net v0.11.0 h1:Gi2tvZIJyBtO9SDr1q9h5hEQCp/4L2RQ+ar0qjx2oNU=
 golang.org/x/net v0.11.0/go.mod h1:2L/ixqYpgIVXmeoSA/4Lu7BzTG4KIyPIryS4IsOd1oQ=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/wasilibs/go-aho-corasick v0.5.0 h1:Y8G8eJ7usuC14sd93IxxnZH43K5Bz5C90a
 github.com/wasilibs/go-aho-corasick v0.5.0/go.mod h1:1XPgz4lvFZA+Ytd8vfeCoqnwy4CSe0MxnLfRQJVqpJM=
 github.com/wasilibs/go-libinjection v0.4.0 h1:dr1Y/kM/gmoA7eSfdf+CvCcmzwsz2jVYjNdakgladDU=
 github.com/wasilibs/go-libinjection v0.4.0/go.mod h1:zD7fNXKSaTKoSTmrfuP9Gc16alNEgwkZaHIeDDk3WWM=
-github.com/wasilibs/go-re2 v1.4.0 h1:Jp6BM8G/zajgY1BCQUm3i7oGMdR1gA5EBv87wGd2ysc=
-github.com/wasilibs/go-re2 v1.4.0/go.mod h1:hLzlKjEgON+17hWjikLx8hJBkikyjQH/lsqCy9t6tIY=
 github.com/wasilibs/go-re2 v1.5.0-pre.1 h1:lJ0RGE6xp9hzFouzLrbEbzdZhpaqzg4rU2rA57eJLmI=
 github.com/wasilibs/go-re2 v1.5.0-pre.1/go.mod h1:GAociXj3tyaHNF0zuZdhEHuODXbPsFpOdg8vuAAq2pw=
 github.com/wasilibs/nottinygc v0.4.0 h1:h1TJMihMC4neN6Zq+WKpLxgd9xCFMw7O9ETLwY2exJQ=

--- a/waf/go.mod
+++ b/waf/go.mod
@@ -38,7 +38,8 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/wasilibs/go-aho-corasick v0.5.0 // indirect
 	github.com/wasilibs/go-libinjection v0.4.0 // indirect
-	github.com/wasilibs/go-re2 v1.4.0 // indirect
+	github.com/wasilibs/go-re2 v1.5.0-pre.1 // indirect
+	github.com/wasilibs/wazerox v0.0.0-20231218050519-52f5e22ee8b5 // indirect
 	github.com/yargevad/filepathx v1.0.0 // indirect
 	golang.org/x/crypto v0.10.0 // indirect
 	golang.org/x/net v0.11.0 // indirect

--- a/waf/go.sum
+++ b/waf/go.sum
@@ -304,9 +304,9 @@ github.com/wasilibs/go-aho-corasick v0.5.0 h1:Y8G8eJ7usuC14sd93IxxnZH43K5Bz5C90a
 github.com/wasilibs/go-aho-corasick v0.5.0/go.mod h1:1XPgz4lvFZA+Ytd8vfeCoqnwy4CSe0MxnLfRQJVqpJM=
 github.com/wasilibs/go-libinjection v0.4.0 h1:dr1Y/kM/gmoA7eSfdf+CvCcmzwsz2jVYjNdakgladDU=
 github.com/wasilibs/go-libinjection v0.4.0/go.mod h1:zD7fNXKSaTKoSTmrfuP9Gc16alNEgwkZaHIeDDk3WWM=
-github.com/wasilibs/go-re2 v1.4.0 h1:Jp6BM8G/zajgY1BCQUm3i7oGMdR1gA5EBv87wGd2ysc=
-github.com/wasilibs/go-re2 v1.4.0/go.mod h1:hLzlKjEgON+17hWjikLx8hJBkikyjQH/lsqCy9t6tIY=
+github.com/wasilibs/go-re2 v1.5.0-pre.1 h1:lJ0RGE6xp9hzFouzLrbEbzdZhpaqzg4rU2rA57eJLmI=
 github.com/wasilibs/nottinygc v0.4.0 h1:h1TJMihMC4neN6Zq+WKpLxgd9xCFMw7O9ETLwY2exJQ=
+github.com/wasilibs/wazerox v0.0.0-20231218050519-52f5e22ee8b5 h1:7GQgc4ewesYeFF8bNxKvsT4q6ngGnGBkCFmwHs1ldwI=
 github.com/yargevad/filepathx v1.0.0 h1:SYcT+N3tYGi+NvazubCNlvgIPbzAk7i7y2dwg3I5FYc=
 github.com/yargevad/filepathx v1.0.0/go.mod h1:BprfX/gpYNJHJfc35GjRRpVcwWXS89gGulUIU5tK3tA=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This is a significant release. AFAIK, most tradeoffs are gone so it will be a no-brainer for any Go code like caddy to use the Wasm path instead of stdlib, though more real-world data is needed.

https://github.com/wasilibs/go-re2/releases/tag/v1.5.0-pre.1