### PR TITLE
chore(ci): harden GHA workflows with least-privilege permissions

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,4 +1,7 @@
 name: Benchmark
+
+permissions: {}
+
 on:
   push:
     branches:
@@ -12,16 +15,18 @@ on:
 jobs:
   bench:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '^1.18.8'
           cache: true
 
       - run: go run mage.go wafbenchall
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: results
           path: build/*bench*.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,7 @@
 name: CI
+
+permissions: {}
+
 on:
   push:
     branches:
@@ -6,11 +9,15 @@ on:
     tags:
       - "*"
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -18,8 +25,8 @@ jobs:
           - macos-12
           - ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '^1.20.14'
           cache: true


### PR DESCRIPTION
## Summary

- Add top-level `permissions: {}` (deny-all default) to all workflows
- Add job-level `permissions: { contents: read }` scoped to each job
- Pin all GitHub Actions to their full commit SHAs (checkout, setup-go, upload-artifact)
- Add `branches: [main]` filter to `pull_request` trigger in CI workflow

## Test plan

- [ ] Verify CI workflow triggers and passes on PRs targeting main
- [ ] Verify Benchmark workflow triggers on pushes to main
- [ ] Confirm actions resolve correctly with pinned SHAs